### PR TITLE
Fix MACS2 call under Python 3

### DIFF
--- a/snaptools/snap.py
+++ b/snaptools/snap.py
@@ -721,7 +721,6 @@ def getFragFromBarcode(fname, barcode_list, barcode_dict):
         barcode_len_list.append(barcode_len);
     barcode_pos_list = list(itertools.chain.from_iterable(barcode_pos_list));
     _chroms = [item.decode() for item in f["FM"]["fragChrom"][barcode_pos_list]];
-    _chroms = [item for item in f["FM"]["fragChrom"][barcode_pos_list]];
     _start = f["FM"]["fragStart"][barcode_pos_list];
     _end = _start + f["FM"]["fragLen"][barcode_pos_list];
     _barcode = [[barcode] * num for (barcode, num) in zip(barcode_list, barcode_len_list)];


### PR DESCRIPTION
Under Python 3, the sequence (chromosome) names provided to MACS2 were retrieved as byte strings, then wrapped in `str()` before writing to disk. This resulted in sequence names like "b'chr1'", as in:

```
b'chr14'      46787083        46787310        AAACATCGAAGGACACCATCAAGT
b'chr3'       56262063        56262116        AAACATCGAAGGACACCATCAAGT
b'chr2'       103894442       103894639       AAACATCGAAGGACACCATCAAGT
```

Tested this fix under Python 2 and 3.